### PR TITLE
Disabling response messaging since any answer is true

### DIFF
--- a/assets/js/slickQuiz.js
+++ b/assets/js/slickQuiz.js
@@ -35,7 +35,7 @@
                 disableScore: false,
                 disableRanking: false,
                 scoreAsPercentage: false,
-                perQuestionResponseMessaging: true,
+                perQuestionResponseMessaging: false,
                 perQuestionResponseAnswers: false,
                 completionResponseMessaging: false,
                 displayQuestionCount: true,   // Deprecate?


### PR DESCRIPTION
This prevents each question from being listed twice & gets rid of the pre-populated messaging ("didn't you go to kindergarten?").